### PR TITLE
Make room url protocol dynamic

### DIFF
--- a/public/js/home.js
+++ b/public/js/home.js
@@ -25,7 +25,7 @@ function shortUrl() {
 function generateRoomUrl() {
     var room = shortUrl();
 	var link = document.getElementById("room-url");
-	roomUrl =  'http://'+window.location.host+'/'+room;
+	roomUrl =  window.location.protocol+'//'+window.location.host+'/'+room;
 	link.href = roomUrl;
 	link.innerHTML = roomUrl;
 }


### PR DESCRIPTION
Given that many browsers now do not allow `getUserMedia` in insecure domains (apart from localhost and private IPs under certain circumstances), this ensures that the correct protocol is used when the domain is secure.